### PR TITLE
SDKIOS-1011 [Investigation] Support ticket for Menzis about pin

### DIFF
--- a/OneWelcomeExampleApp.xcodeproj/project.pbxproj
+++ b/OneWelcomeExampleApp.xcodeproj/project.pbxproj
@@ -1700,7 +1700,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onewelcome.OneginiExampleAppSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "OneWelcomeExampleApp/SupportingFiles/OneWelcomeExampleApp-Bridging-Header.h";
@@ -1727,7 +1727,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onewelcome.OneginiExampleAppSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "OneWelcomeExampleApp/SupportingFiles/OneWelcomeExampleApp-Bridging-Header.h";

--- a/OneWelcomeExampleApp/Interactors/ChangePinInteractor.swift
+++ b/OneWelcomeExampleApp/Interactors/ChangePinInteractor.swift
@@ -18,6 +18,7 @@ import UIKit
 protocol ChangePinInteractorProtocol: AnyObject {
     func changePin()
     func handlePin()
+    func handlePinPolicy(pin: String, completion: @escaping (Error?) -> Void)
 }
 
 class ChangePinInteractor: NSObject {
@@ -48,6 +49,12 @@ class ChangePinInteractor: NSObject {
             handleCreatePin()
         } else {
             handleLogin()
+        }
+    }
+    
+    func handlePinPolicy(pin: String, completion: @escaping (Error?) -> Void) {
+        userClient.validatePolicyCompliance(for: pin) { error in
+            completion(error)
         }
     }
 

--- a/OneWelcomeExampleApp/Presenters/AuthenticatorsPresenter.swift
+++ b/OneWelcomeExampleApp/Presenters/AuthenticatorsPresenter.swift
@@ -125,6 +125,10 @@ extension AuthenticatorsPresenter: AuthenticatorsViewToPresenterProtocol {
 }
 
 extension AuthenticatorsPresenter: PinViewToPresenterProtocol {
+    func handlePinPolicy(pin: String, completion: (Error?) -> Void) {
+        // TODO: implement if needed
+    }
+    
     func handlePin() {
         authenticatorsInteractor.handleLogin()
     }

--- a/OneWelcomeExampleApp/Presenters/ChangePinPresenter.swift
+++ b/OneWelcomeExampleApp/Presenters/ChangePinPresenter.swift
@@ -98,4 +98,8 @@ extension ChangePinPresenter: PinViewToPresenterProtocol {
     func handlePin() {
         changePinInteractor.handlePin()
     }
+    
+    func handlePinPolicy(pin: String, completion: @escaping (Error?) -> Void) {
+        changePinInteractor.handlePinPolicy(pin: pin, completion: completion)
+    }
 }

--- a/OneWelcomeExampleApp/Presenters/LoginPresenter.swift
+++ b/OneWelcomeExampleApp/Presenters/LoginPresenter.swift
@@ -158,6 +158,10 @@ extension LoginPresenter: LoginViewDelegate {
 }
 
 extension LoginPresenter: PinViewToPresenterProtocol {
+    func handlePinPolicy(pin: String, completion: (Error?) -> Void) {
+        // TODO: implement if needed
+    }
+    
     func handlePin() {
         loginInteractor.handleLogin()
     }

--- a/OneWelcomeExampleApp/Presenters/MobileAuthPresenter.swift
+++ b/OneWelcomeExampleApp/Presenters/MobileAuthPresenter.swift
@@ -208,6 +208,10 @@ extension MobileAuthPresenter: PushMobileAuthEntrollmentProtocol {
 }
 
 extension MobileAuthPresenter: PinViewToPresenterProtocol {
+    func handlePinPolicy(pin: String, completion: (Error?) -> Void) {
+        // TODO: implement if needed
+    }
+    
     func handlePin() {
         mobileAuthInteractor.handlePinMobileAuth()
     }

--- a/OneWelcomeExampleApp/Presenters/RegisterUserPresenter.swift
+++ b/OneWelcomeExampleApp/Presenters/RegisterUserPresenter.swift
@@ -126,6 +126,10 @@ extension RegisterUserPresenter: RegisterUserViewToPresenterProtocol {
 }
 
 extension RegisterUserPresenter: PinViewToPresenterProtocol {
+    func handlePinPolicy(pin: String, completion: (Error?) -> Void) {
+        // TODO: implement if needed
+    }
+    
     func handlePin() {
         registerUserInteractor.handleCreatedPin()
     }


### PR DESCRIPTION
Added an example how to use already built-in SDK's API to check if the pin meets the pin policy. 

NOTE: No update to the SDK is needed! It's already here, more info: https://developer.onewelcome.com/ios/sdk/change-pin#validation


https://github.com/onewelcome/example-app-ios/assets/91735443/df7fe699-d7f2-48e1-ade3-a59fa39f8d2f

